### PR TITLE
User's weight may be a float

### DIFF
--- a/userinfo.go
+++ b/userinfo.go
@@ -7,10 +7,10 @@ import (
 
 // UserInfo is the information for the current user
 type UserInfo struct {
-	Age    int    `json:"age"`
-	Weight int    `json:"weight"`
-	Gender string `json:"gender"`
-	Email  string `json:"email"`
+	Age    int     `json:"age"`
+	Weight float64 `json:"weight"`
+	Gender string  `json:"gender"`
+	Email  string  `json:"email"`
 }
 
 // GetUserInfo returns the user information for the current user

--- a/userinfo_test.go
+++ b/userinfo_test.go
@@ -2,7 +2,6 @@ package oura
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -10,27 +9,55 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var infoTestCases = []struct {
+	name     string
+	mock     string
+	expected UserInfo
+}{
+	{
+		name: "Regular info",
+		mock: `{
+			"age": 27,
+			"weight": 80,
+			"gender": "male",
+			"email": "john.doe@the.domain"
+		}`,
+		expected: UserInfo{
+			Age:    27,
+			Weight: 80.0,
+			Gender: "male",
+			Email:  "john.doe@the.domain",
+		},
+	},
+	{
+		name: "Info w/ weight as float",
+		mock: `{
+			"age": 27,
+			"weight": 80.0,
+			"gender": "male",
+			"email": "john.doe@the.domain"
+		}`,
+		expected: UserInfo{
+			Age:    27,
+			Weight: 80.0,
+			Gender: "male",
+			Email:  "john.doe@the.domain",
+		},
+	},
+}
+
 func TestUserInfo(t *testing.T) {
-	mock := `{
-		"age": 27,
-		"weight": 80,
-		"gender": "male",
-		"email": "john.doe@the.domain"
-	}`
+	for _, tc := range infoTestCases {
+		client, mux, _, teardown := setup()
+		defer teardown()
 
-	client, mux, _, teardown := setup()
-	defer teardown()
+		mux.HandleFunc("/userinfo", func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			fmt.Fprint(w, tc.mock)
+		})
 
-	mux.HandleFunc("/userinfo", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodGet, r.Method)
-		fmt.Fprint(w, mock)
-	})
-
-	got, _, err := client.GetUserInfo(context.Background())
-	assert.NoError(t, err, "should not return an error")
-
-	want := &UserInfo{}
-	json.Unmarshal([]byte(mock), want)
-
-	assert.ObjectsAreEqual(want, got)
+		got, _, err := client.GetUserInfo(context.Background())
+		assert.NoError(t, err, tc.name+" should not return an error")
+		assert.ObjectsAreEqual(tc.expected, got)
+	}
 }


### PR DESCRIPTION
The Oura API doesn't make it clear the user's weight could be a float, but it makes sense that it does. This PR fixes https://github.com/lildude/oura/issues/2 and extends the tests to test for both ints and floats.

Thanks @pfiaux 🙇 