### PR TITLE
misc: Update goreleaser config to use github-native for changelog

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,11 +2,12 @@ builds:
   - skip: true
 changelog:
   sort: asc
-  use: github
+  use: github-native
   filters:
     exclude:
       - '^docs:'
       - '^test:'
+      - '^misc:'
       - '^Merge pull request'
 release:
   draft: true


### PR DESCRIPTION
I prefer this and want to save myself a few button clicks.